### PR TITLE
Add missing include for uintptr_t

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 # Ex-Maintainer: K0n24d <konrad AT knauber DOT net>
 pkgname=urbackup2-client
 pkgver=2.5.24
-pkgrel=1
+pkgrel=2
 pkgdesc="Client Server backup system"
 arch=('i686' 'x86_64' 'armv5' 'armv6h' 'armv6' 'armv7h' 'armv7' 'aarch64')
 url="http://www.urbackup.org/"
@@ -20,6 +20,7 @@ source=(
     'lvm_create_filesystem_snapshot'
     'lvm_remove_filesystem_snapshot'
     'md5-bytes.patch'
+    'uintptr_t.patch'
 )
 sha512sums=('4ea34c708fecb77774d63c596182fad3d5be2a11b8ae44247e1401299cb712faca8e124d245136f220ffc2c790f65adfd8ab0cf2c9bdccafabc17a3f7c25feb8'
             '416fb8f5f3687a3c369cc2b199d4c8b4170494f0a119566a91ac6a0c2f202dc5049804c10508b66ba657011b39be5ddd055091cd531a665b4398899f404086ca'
@@ -29,7 +30,8 @@ sha512sums=('4ea34c708fecb77774d63c596182fad3d5be2a11b8ae44247e1401299cb712faca8
             '238c286d451474a8721292f7e98b4f13600cb430c16a27ceb9551cc83705b8268a3f1202785fb5b61523f372b4e7e804fd20b7db62677621983d79a271aa106b'
             'a2d4ba03ae15582d2cd74ff68c38ff0f90d75a6eb5c241f9a022b0652fa2dc9b184439f6bda9a9538645925f739503ee7b3fc7bb232589583cdeb6dc27d74e5c'
             '9bdfefccdd9d6e37a77975324a7c417f3de2aa59e6da0bfde3c318b8c6f3d7f4629f3a41eebee548b9c572b8ed39640434cc08bd020d25362fddffc4426438de'
-            '34e25c868cf4572414fbc6c693877127152f9a97edf8865b4263a55cf16f71a5045ba96b1a9af8244ed49c35cab56e3fdb44348d191e9f85e2efb66392907132')
+            '34e25c868cf4572414fbc6c693877127152f9a97edf8865b4263a55cf16f71a5045ba96b1a9af8244ed49c35cab56e3fdb44348d191e9f85e2efb66392907132'
+            '46a89313447c2aee40943e800bb79d05e30bb9f89fcd48e37ca1a0f9226efbfed20b0ff02cc88e03ed904069b98008525a66856568dbe57d1380389d74e4b091')
 
 CFLAGS="-march=native -O2 -pipe -fstack-protector-strong"
 CXXFLAGS="${CFLAGS} -ansi -std=gnu++11"
@@ -40,6 +42,8 @@ build() {
     sed  -i '/\#include \"cryptopp_inc.h\"/a #include "assert.h"' "${srcdir}/urbackup-client-${pkgver}.0/cryptoplugin/AESGCMDecryption.h"
 
     patch -d"${srcdir}/urbackup-client-${pkgver}.0" -p0 < "${srcdir}/md5-bytes.patch"
+
+    patch -d"${srcdir}/urbackup-client-${pkgver}.0" -p1 < "${srcdir}/uintptr_t.patch"
 
     cd "${srcdir}/urbackup-client-${pkgver}.0"
     ./configure --prefix=/usr --sbindir=/usr/bin --localstatedir=/var --sysconfdir=/etc --enable-embedded-cryptopp

--- a/uintptr_t.patch
+++ b/uintptr_t.patch
@@ -1,0 +1,12 @@
+diff -ur urbackup-client-2.5.24.0/blockalign_src/crc.cpp urbackup-client-2.5.24.0-new/blockalign_src/crc.cpp
+--- urbackup-client-2.5.24.0/blockalign_src/crc.cpp	2022-08-21 10:45:31.000000000 +0200
++++ urbackup-client-2.5.24.0-new/blockalign_src/crc.cpp	2023-05-21 15:37:32.101668783 +0200
+@@ -118,6 +118,8 @@
+ # include <stdint.h>
+ #elif defined(_MSC_VER) && (_MSC_VER < 1700)
+ # include <stddef.h>
++#else
++# include <cstdint>
+ #endif
+ 
+ #if CRYPTOPP_BOOL_SSE4_INTRINSICS_AVAILABLE


### PR DESCRIPTION
uintptr_t is included in C++11 (optionally), but you still have to include the actual header.